### PR TITLE
Fix to make the login fields blank when no URL or consumer key is spe…

### DIFF
--- a/app/routers/login.js
+++ b/app/routers/login.js
@@ -12,8 +12,8 @@ router.get('/', function(req, res){
 
     res.render('login', {
         title: 'Login',
-        defaultLoginUrl: req.query.loginUrl || config.defaultLoginUrl,
-        defaultConsumerKey: req.query.consumerKey || config.defaultConsumerKey,
+        defaultLoginUrl: req.query.loginUrl || config.defaultLoginUrl || '',
+        defaultConsumerKey: req.query.consumerKey || config.defaultConsumerKey || '',
         state: state,
         redirectPath: redirectPath
     });


### PR DESCRIPTION
Currently, they will display "undefined" when no environment config or query param is specified.