### PR TITLE
Update NotFoundError.js

### DIFF
--- a/client-src/components/errors/NotFoundError.js
+++ b/client-src/components/errors/NotFoundError.js
@@ -7,7 +7,6 @@ const NotFoundError = () => {
       <div>Unable to contact the server. This could be caused by the following reasons:</div>
       <ul style="list-style: initial; margin-top: 1em;">
         <li style="margin-left: 3em;">The server from the target URL is not accessible.</li>
-        <li style="margin-left: 3em;">The organization doesn't have the <code>LightningApi</code> OrgPerm enabled.</li>
         <li style="margin-left: 3em;">The organization doesn't have CORS enabled. See the <a href="https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/extend_code_cors.htm" target="_blank">docs</a> on how to setup CORS.</li>
       </ul>
     </article>


### PR DESCRIPTION
Isn't the perm on for all orgs now? 
Do you mean "The server isn't accessible from the target URL"? Are there any common reasons?